### PR TITLE
v1.6.0

### DIFF
--- a/lib/blocs/boulder_bloc.dart
+++ b/lib/blocs/boulder_bloc.dart
@@ -1,4 +1,5 @@
 import 'package:breizh_blok_mobile/blocs/boulder_filter_bloc.dart';
+import 'package:breizh_blok_mobile/models/grade.dart';
 import 'package:breizh_blok_mobile/models/order_query_param.dart';
 import 'package:breizh_blok_mobile/repositories/boulder_repository.dart';
 import 'package:breizh_blok_mobile/utils/boulder_list_query_params_builder.dart';
@@ -19,6 +20,7 @@ class BoulderBloc
           emit: emit,
           filterState: event.filterState,
           orderQueryParam: event.orderQueryParam,
+          grades: event.grades,
         );
       },
     );
@@ -33,6 +35,7 @@ class BoulderBloc
           },
           filterState: event.filterState,
           orderQueryParam: event.orderQueryParam,
+          grades: {},
         );
       },
     );
@@ -44,6 +47,7 @@ class BoulderBloc
     Map<String, List<String>>? extraQueryParams,
     required BoulderFilterState filterState,
     required OrderQueryParam orderQueryParam,
+    required Set<Grade> grades,
   }) async {
     Map<String, List<String>> queryParams = {
       'page': [
@@ -52,6 +56,7 @@ class BoulderBloc
       ...await BoulderListQueryParamsBuilder.compute(
         filterState: filterState,
         orderQueryParam: orderQueryParam,
+        grades: grades,
       ),
       ...(extraQueryParams ?? {}),
     };
@@ -77,11 +82,13 @@ class BoulderListViewRequested extends BoulderEvent {
   final int page;
   final BoulderFilterState filterState;
   final OrderQueryParam orderQueryParam;
+  final Set<Grade> grades;
 
   BoulderListViewRequested({
     required this.page,
     required this.filterState,
     required this.orderQueryParam,
+    required this.grades,
   });
 }
 

--- a/lib/blocs/boulder_bloc.dart
+++ b/lib/blocs/boulder_bloc.dart
@@ -1,4 +1,5 @@
 import 'package:breizh_blok_mobile/blocs/boulder_filter_bloc.dart';
+import 'package:breizh_blok_mobile/models/order_query_param.dart';
 import 'package:breizh_blok_mobile/repositories/boulder_repository.dart';
 import 'package:breizh_blok_mobile/utils/boulder_list_query_params_builder.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -17,6 +18,7 @@ class BoulderBloc
           page: event.page,
           emit: emit,
           filterState: event.filterState,
+          orderQueryParam: event.orderQueryParam,
         );
       },
     );
@@ -30,6 +32,7 @@ class BoulderBloc
             'id[]': event.boulderIds,
           },
           filterState: event.filterState,
+          orderQueryParam: event.orderQueryParam,
         );
       },
     );
@@ -40,12 +43,16 @@ class BoulderBloc
     required Emitter<Response<CollectionItems<Boulder>>> emit,
     Map<String, List<String>>? extraQueryParams,
     required BoulderFilterState filterState,
+    required OrderQueryParam orderQueryParam,
   }) async {
     Map<String, List<String>> queryParams = {
       'page': [
         page.toString(),
       ],
-      ...await BoulderListQueryParamsBuilder.compute(filterState),
+      ...await BoulderListQueryParamsBuilder.compute(
+        filterState: filterState,
+        orderQueryParam: orderQueryParam,
+      ),
       ...(extraQueryParams ?? {}),
     };
 
@@ -69,10 +76,12 @@ abstract class BoulderEvent {}
 class BoulderListViewRequested extends BoulderEvent {
   final int page;
   final BoulderFilterState filterState;
+  final OrderQueryParam orderQueryParam;
 
   BoulderListViewRequested({
     required this.page,
     required this.filterState,
+    required this.orderQueryParam,
   });
 }
 
@@ -80,10 +89,12 @@ class BoulderMapViewRequested extends BoulderEvent {
   final int page;
   final List<String> boulderIds;
   final BoulderFilterState filterState;
+  final OrderQueryParam orderQueryParam;
 
   BoulderMapViewRequested({
     required this.page,
     required this.boulderIds,
     required this.filterState,
+    required this.orderQueryParam,
   });
 }

--- a/lib/blocs/boulder_filter_bloc.dart
+++ b/lib/blocs/boulder_filter_bloc.dart
@@ -1,6 +1,5 @@
 import 'package:breizh_blok_mobile/models/boulder_area.dart';
 import 'package:breizh_blok_mobile/models/grade.dart';
-import 'package:breizh_blok_mobile/models/order_query_param.dart';
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
@@ -21,12 +20,6 @@ class BoulderFilterBloc extends Bloc<BoulderFilterEvent, BoulderFilterState> {
     on<BoulderFilterGrade>(
       (event, emit) {
         emit(state.copyWith(grades: event.grades));
-      },
-    );
-
-    on<BoulderFilterOrder>(
-      (event, emit) {
-        emit(state.copyWith(order: event.order));
       },
     );
   }
@@ -52,42 +45,30 @@ class BoulderFilterGrade extends BoulderFilterEvent {
   BoulderFilterGrade(this.grades);
 }
 
-class BoulderFilterOrder extends BoulderFilterEvent {
-  final OrderQueryParam order;
-
-  BoulderFilterOrder(this.order);
-}
-
 class BoulderFilterState extends Equatable {
   final String? term;
   final Set<BoulderArea> boulderAreas;
   final Set<Grade> grades;
-  final OrderQueryParam order;
 
   BoulderFilterState({
     this.term,
     Set<BoulderArea>? boulderAreas,
     Set<Grade>? grades,
-    order,
-  })  : order = order ??
-            const OrderQueryParam(name: 'order[id]', direction: 'desc'),
-        boulderAreas = boulderAreas ?? <BoulderArea>{},
+  })  : boulderAreas = boulderAreas ?? <BoulderArea>{},
         grades = grades ?? <Grade>{};
 
   @override
-  List<Object?> get props => [term, boulderAreas, grades, order];
+  List<Object?> get props => [term, boulderAreas, grades];
 
   BoulderFilterState copyWith({
     String? term,
     Set<BoulderArea>? boulderAreas,
     Set<Grade>? grades,
-    OrderQueryParam? order,
   }) {
     return BoulderFilterState(
       term: term ?? this.term,
       boulderAreas: boulderAreas ?? this.boulderAreas,
       grades: grades ?? this.grades,
-      order: order ?? this.order,
     );
   }
 }

--- a/lib/blocs/boulder_filter_bloc.dart
+++ b/lib/blocs/boulder_filter_bloc.dart
@@ -1,5 +1,4 @@
 import 'package:breizh_blok_mobile/models/boulder_area.dart';
-import 'package:breizh_blok_mobile/models/grade.dart';
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
@@ -14,12 +13,6 @@ class BoulderFilterBloc extends Bloc<BoulderFilterEvent, BoulderFilterState> {
     on<BoulderFilterLocation>(
       (event, emit) {
         emit(state.copyWith(boulderAreas: event.boulderAreas));
-      },
-    );
-
-    on<BoulderFilterGrade>(
-      (event, emit) {
-        emit(state.copyWith(grades: event.grades));
       },
     );
   }
@@ -39,36 +32,25 @@ class BoulderFilterLocation extends BoulderFilterEvent {
   BoulderFilterLocation(this.boulderAreas);
 }
 
-class BoulderFilterGrade extends BoulderFilterEvent {
-  final Set<Grade> grades;
-
-  BoulderFilterGrade(this.grades);
-}
-
 class BoulderFilterState extends Equatable {
   final String? term;
   final Set<BoulderArea> boulderAreas;
-  final Set<Grade> grades;
 
   BoulderFilterState({
     this.term,
     Set<BoulderArea>? boulderAreas,
-    Set<Grade>? grades,
-  })  : boulderAreas = boulderAreas ?? <BoulderArea>{},
-        grades = grades ?? <Grade>{};
+  }) : boulderAreas = boulderAreas ?? <BoulderArea>{};
 
   @override
-  List<Object?> get props => [term, boulderAreas, grades];
+  List<Object?> get props => [term, boulderAreas];
 
   BoulderFilterState copyWith({
     String? term,
     Set<BoulderArea>? boulderAreas,
-    Set<Grade>? grades,
   }) {
     return BoulderFilterState(
       term: term ?? this.term,
       boulderAreas: boulderAreas ?? this.boulderAreas,
-      grades: grades ?? this.grades,
     );
   }
 }

--- a/lib/blocs/boulder_filter_grade_bloc.dart
+++ b/lib/blocs/boulder_filter_grade_bloc.dart
@@ -1,0 +1,28 @@
+import 'package:breizh_blok_mobile/models/grade.dart';
+import 'package:equatable/equatable.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+class BoulderFilterGradeBloc
+    extends Bloc<BoulderFilterGradeEvent, BoulderFilterGradeState> {
+  BoulderFilterGradeBloc(BoulderFilterGradeState initialState)
+      : super(initialState) {
+    on<BoulderFilterGradeEvent>(
+      (event, emit) => emit(BoulderFilterGradeState(grades: event.grades)),
+    );
+  }
+}
+
+class BoulderFilterGradeEvent {
+  final Set<Grade> grades;
+
+  BoulderFilterGradeEvent(this.grades);
+}
+
+class BoulderFilterGradeState extends Equatable {
+  final Set<Grade> grades;
+
+  BoulderFilterGradeState({Set<Grade>? grades}) : grades = grades ?? <Grade>{};
+
+  @override
+  List<Object?> get props => [grades];
+}

--- a/lib/blocs/boulder_marker_bloc.dart
+++ b/lib/blocs/boulder_marker_bloc.dart
@@ -27,6 +27,7 @@ class BoulderMarkerBloc extends Bloc<BoulderMarkerEvent, BoulderMarkerState> {
           ...await BoulderListQueryParamsBuilder.compute(
             filterState: event.filterState,
             orderQueryParam: event.orderQueryParam,
+            grades: {},
           ),
         };
 

--- a/lib/blocs/boulder_marker_bloc.dart
+++ b/lib/blocs/boulder_marker_bloc.dart
@@ -1,4 +1,5 @@
 import 'package:breizh_blok_mobile/blocs/boulder_filter_bloc.dart';
+import 'package:breizh_blok_mobile/models/order_query_param.dart';
 import 'package:breizh_blok_mobile/repositories/boulder_marker_repository.dart';
 import 'package:breizh_blok_mobile/utils/boulder_list_query_params_builder.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -24,7 +25,8 @@ class BoulderMarkerBloc extends Bloc<BoulderMarkerEvent, BoulderMarkerState> {
           'pagination': ['false'],
           'groups[]': ['Boulder:map'],
           ...await BoulderListQueryParamsBuilder.compute(
-            event.filterState,
+            filterState: event.filterState,
+            orderQueryParam: event.orderQueryParam,
           ),
         };
 
@@ -49,8 +51,12 @@ abstract class BoulderMarkerEvent {}
 
 class BoulderMarkerRequested extends BoulderMarkerEvent {
   final BoulderFilterState filterState;
+  final OrderQueryParam orderQueryParam;
 
-  BoulderMarkerRequested({required this.filterState});
+  BoulderMarkerRequested({
+    required this.filterState,
+    required this.orderQueryParam,
+  });
 }
 
 class BoulderMarkerState extends Equatable {

--- a/lib/blocs/boulder_order_bloc.dart
+++ b/lib/blocs/boulder_order_bloc.dart
@@ -1,0 +1,18 @@
+import 'package:breizh_blok_mobile/models/order_query_param.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+class BoulderOrderBloc extends Bloc<BoulderOrderEvent, OrderQueryParam> {
+  BoulderOrderBloc(OrderQueryParam initialState) : super(initialState) {
+    on<BoulderOrderEvent>(
+      (event, emit) {
+        emit(event.order);
+      },
+    );
+  }
+}
+
+class BoulderOrderEvent {
+  final OrderQueryParam order;
+
+  BoulderOrderEvent(this.order);
+}

--- a/lib/components/boulder_area_details.dart
+++ b/lib/components/boulder_area_details.dart
@@ -1,5 +1,6 @@
 import 'package:breizh_blok_mobile/blocs/boulder_bloc.dart';
 import 'package:breizh_blok_mobile/blocs/boulder_filter_bloc.dart';
+import 'package:breizh_blok_mobile/blocs/boulder_filter_grade_bloc.dart';
 import 'package:breizh_blok_mobile/blocs/boulder_marker_bloc.dart';
 import 'package:breizh_blok_mobile/blocs/boulder_order_bloc.dart';
 import 'package:breizh_blok_mobile/blocs/map_bloc.dart';
@@ -76,6 +77,7 @@ class BoulderAreaDetails extends StatelessWidget {
             page: page,
             filterState: context.read<BoulderFilterBloc>().state,
             orderQueryParam: context.read<BoulderOrderBloc>().state,
+            grades: context.read<BoulderFilterGradeBloc>().state.grades,
           );
         },
       ),

--- a/lib/components/boulder_area_details.dart
+++ b/lib/components/boulder_area_details.dart
@@ -1,6 +1,7 @@
 import 'package:breizh_blok_mobile/blocs/boulder_bloc.dart';
 import 'package:breizh_blok_mobile/blocs/boulder_filter_bloc.dart';
 import 'package:breizh_blok_mobile/blocs/boulder_marker_bloc.dart';
+import 'package:breizh_blok_mobile/blocs/boulder_order_bloc.dart';
 import 'package:breizh_blok_mobile/blocs/map_bloc.dart';
 import 'package:breizh_blok_mobile/components/app_bar_helper.dart';
 import 'package:breizh_blok_mobile/components/boulder_list_builder.dart';
@@ -49,7 +50,9 @@ class BoulderAreaDetails extends StatelessWidget {
   Widget build(BuildContext context) {
     context.read<BoulderMarkerBloc>().add(
           BoulderMarkerRequested(
-              filterState: context.read<BoulderFilterBloc>().state),
+            filterState: context.read<BoulderFilterBloc>().state,
+            orderQueryParam: context.read<BoulderOrderBloc>().state,
+          ),
         );
 
     final location = boulderArea.resolveLocation();
@@ -71,6 +74,7 @@ class BoulderAreaDetails extends StatelessWidget {
           return BoulderListViewRequested(
             page: page,
             filterState: context.read<BoulderFilterBloc>().state,
+            orderQueryParam: context.read<BoulderOrderBloc>().state,
           );
         },
       ),
@@ -119,6 +123,7 @@ class BoulderAreaDetails extends StatelessWidget {
                       context,
                       boulderFilterState:
                           context.read<BoulderFilterBloc>().state,
+                      orderQueryParam: context.read<BoulderOrderBloc>().state,
                     ),
                     markers: parkingLocation == null
                         ? {}

--- a/lib/components/boulder_area_details.dart
+++ b/lib/components/boulder_area_details.dart
@@ -70,6 +70,7 @@ class BoulderAreaDetails extends StatelessWidget {
         boulderArea.numberOfBouldersGroupedByGrade;
     final tabViews = [
       BoulderListBuilder(
+        boulderFilterBloc: context.read<BoulderFilterBloc>(),
         onPageRequested: (int page) {
           return BoulderListViewRequested(
             page: page,
@@ -121,9 +122,6 @@ class BoulderAreaDetails extends StatelessWidget {
                     initialZoom: context.watch<MapBloc>().state.mapZoom,
                     boulderMarkerBuilder: markerBuilderFactory(
                       context,
-                      boulderFilterState:
-                          context.read<BoulderFilterBloc>().state,
-                      orderQueryParam: context.read<BoulderOrderBloc>().state,
                     ),
                     markers: parkingLocation == null
                         ? {}

--- a/lib/components/boulder_list_builder.dart
+++ b/lib/components/boulder_list_builder.dart
@@ -148,31 +148,34 @@ class _BoulderListBuilderState extends State<BoulderListBuilder> {
                       onClickTile: widget.onClickTile,
                     );
                     if (index == 0) {
-                      return Column(
-                        children: [
-                          Row(
-                            crossAxisAlignment: CrossAxisAlignment.center,
-                            children: [
-                              const SortBouldersButton(),
-                              if (widget.showFilterButton)
-                                const FilterBouldersButton(),
-                              Expanded(
-                                child: Padding(
-                                  padding: const EdgeInsets.only(right: 8.0),
-                                  child: BoulderListResults(
-                                    key: const Key('boulder-list-result'),
-                                    totalItems:
-                                        _bloc.state.data?.totalItems ?? 0,
+                      return Padding(
+                        padding: const EdgeInsets.only(top: 8.0),
+                        child: Column(
+                          children: [
+                            Row(
+                              crossAxisAlignment: CrossAxisAlignment.center,
+                              children: [
+                                const SortBouldersButton(),
+                                if (widget.showFilterButton)
+                                  const FilterBouldersButton(),
+                                Expanded(
+                                  child: Padding(
+                                    padding: const EdgeInsets.only(right: 8.0),
+                                    child: BoulderListResults(
+                                      key: const Key('boulder-list-result'),
+                                      totalItems:
+                                          _bloc.state.data?.totalItems ?? 0,
+                                    ),
                                   ),
                                 ),
-                              ),
-                            ],
-                          ),
-                          const SizedBox(
-                            height: 10,
-                          ),
-                          tile
-                        ],
+                              ],
+                            ),
+                            const SizedBox(
+                              height: 10,
+                            ),
+                            tile
+                          ],
+                        ),
                       );
                     }
                     return tile;

--- a/lib/components/boulder_list_builder.dart
+++ b/lib/components/boulder_list_builder.dart
@@ -22,11 +22,15 @@ import 'package:breizh_blok_mobile/components/boulder_list_results.dart';
 class BoulderListBuilder extends StatefulWidget {
   final Function onPageRequested;
   final Function? onClickTile;
+  final BoulderFilterBloc boulderFilterBloc;
+  final bool showFilterButton;
 
   const BoulderListBuilder({
     Key? key,
     required this.onPageRequested,
     this.onClickTile,
+    required this.boulderFilterBloc,
+    this.showFilterButton = true,
   }) : super(key: key);
 
   @override
@@ -120,7 +124,7 @@ class _BoulderListBuilderState extends State<BoulderListBuilder> {
                 pagingController: _pagingController,
                 scrollController: _scrollController,
                 padding: const EdgeInsets.only(
-                    bottom: 16, left: 10, right: 10, top: 0),
+                    bottom: 16, left: 10, right: 10, top: 5),
                 separatorBuilder: (context, index) => const SizedBox(
                   height: 16,
                 ),
@@ -144,7 +148,10 @@ class _BoulderListBuilderState extends State<BoulderListBuilder> {
                             crossAxisAlignment: CrossAxisAlignment.center,
                             children: [
                               const SortBouldersButton(),
-                              const FilterBouldersButton(),
+                              if (widget.showFilterButton)
+                                FilterBouldersButton(
+                                  boulderFilterBloc: widget.boulderFilterBloc,
+                                ),
                               Expanded(
                                 child: Padding(
                                   padding: const EdgeInsets.only(right: 8.0),

--- a/lib/components/boulder_list_builder.dart
+++ b/lib/components/boulder_list_builder.dart
@@ -1,8 +1,10 @@
 import 'dart:async';
 
+import 'package:breizh_blok_mobile/blocs/boulder_order_bloc.dart';
 import 'package:breizh_blok_mobile/components/boulder_list_back_to_top_button.dart';
 import 'package:breizh_blok_mobile/components/filter_boulders_button.dart';
 import 'package:breizh_blok_mobile/components/sort_boulders_button.dart';
+import 'package:breizh_blok_mobile/models/order_query_param.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:infinite_scroll_pagination/infinite_scroll_pagination.dart';
@@ -76,6 +78,11 @@ class _BoulderListBuilderState extends State<BoulderListBuilder> {
     return MultiBlocListener(
       listeners: [
         BlocListener<BoulderFilterBloc, BoulderFilterState>(
+          listener: (context, state) {
+            _pagingController.refresh();
+          },
+        ),
+        BlocListener<BoulderOrderBloc, OrderQueryParam>(
           listener: (context, state) {
             _pagingController.refresh();
           },

--- a/lib/components/boulder_list_builder.dart
+++ b/lib/components/boulder_list_builder.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:breizh_blok_mobile/blocs/boulder_filter_grade_bloc.dart';
 import 'package:breizh_blok_mobile/blocs/boulder_order_bloc.dart';
 import 'package:breizh_blok_mobile/components/boulder_list_back_to_top_button.dart';
 import 'package:breizh_blok_mobile/components/filter_boulders_button.dart';
@@ -91,6 +92,11 @@ class _BoulderListBuilderState extends State<BoulderListBuilder> {
             _pagingController.refresh();
           },
         ),
+        BlocListener<BoulderFilterGradeBloc, BoulderFilterGradeState>(
+          listener: (context, state) {
+            _pagingController.refresh();
+          },
+        ),
         BlocListener<BoulderBloc, Response<CollectionItems<Boulder>>>(
           listener: (context, state) {
             if (state.error != null) {
@@ -149,9 +155,7 @@ class _BoulderListBuilderState extends State<BoulderListBuilder> {
                             children: [
                               const SortBouldersButton(),
                               if (widget.showFilterButton)
-                                FilterBouldersButton(
-                                  boulderFilterBloc: widget.boulderFilterBloc,
-                                ),
+                                const FilterBouldersButton(),
                               Expanded(
                                 child: Padding(
                                   padding: const EdgeInsets.only(right: 8.0),

--- a/lib/components/boulder_list_filter_grade.dart
+++ b/lib/components/boulder_list_filter_grade.dart
@@ -1,15 +1,15 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
-
 import 'package:breizh_blok_mobile/models/collection_items.dart';
 import 'package:breizh_blok_mobile/models/grade.dart';
 import 'package:breizh_blok_mobile/blocs/boulder_filter_bloc.dart';
 import 'package:syncfusion_flutter_sliders/sliders.dart';
 
 class BoulderListFilterGrade extends StatefulWidget {
+  final BoulderFilterBloc boulderFilterBloc;
   const BoulderListFilterGrade({
     Key? key,
     required this.allGrades,
+    required this.boulderFilterBloc,
   }) : super(key: key);
 
   final CollectionItems<Grade> allGrades;
@@ -25,7 +25,7 @@ class _BoulderListFilterGradeState extends State<BoulderListFilterGrade> {
   void initState() {
     super.initState();
     final List<Grade> selectedGrades =
-        context.read<BoulderFilterBloc>().state.grades.toList();
+        widget.boulderFilterBloc.state.grades.toList();
     selectedGrades.sort((a, b) => a.name.compareTo(b.name));
 
     if (selectedGrades.isEmpty) {
@@ -121,9 +121,9 @@ class _BoulderListFilterGradeState extends State<BoulderListFilterGrade> {
                   };
                 }
 
-                context.read<BoulderFilterBloc>().add(BoulderFilterGrade(
-                      newValues,
-                    ));
+                widget.boulderFilterBloc.add(BoulderFilterGrade(
+                  newValues,
+                ));
               },
             )),
       ],

--- a/lib/components/boulder_list_filter_grade.dart
+++ b/lib/components/boulder_list_filter_grade.dart
@@ -1,15 +1,14 @@
+import 'package:breizh_blok_mobile/blocs/boulder_filter_grade_bloc.dart';
 import 'package:flutter/material.dart';
 import 'package:breizh_blok_mobile/models/collection_items.dart';
 import 'package:breizh_blok_mobile/models/grade.dart';
-import 'package:breizh_blok_mobile/blocs/boulder_filter_bloc.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:syncfusion_flutter_sliders/sliders.dart';
 
 class BoulderListFilterGrade extends StatefulWidget {
-  final BoulderFilterBloc boulderFilterBloc;
   const BoulderListFilterGrade({
     Key? key,
     required this.allGrades,
-    required this.boulderFilterBloc,
   }) : super(key: key);
 
   final CollectionItems<Grade> allGrades;
@@ -25,7 +24,7 @@ class _BoulderListFilterGradeState extends State<BoulderListFilterGrade> {
   void initState() {
     super.initState();
     final List<Grade> selectedGrades =
-        widget.boulderFilterBloc.state.grades.toList();
+        context.read<BoulderFilterGradeBloc>().state.grades.toList();
     selectedGrades.sort((a, b) => a.name.compareTo(b.name));
 
     if (selectedGrades.isEmpty) {
@@ -121,9 +120,11 @@ class _BoulderListFilterGradeState extends State<BoulderListFilterGrade> {
                   };
                 }
 
-                widget.boulderFilterBloc.add(BoulderFilterGrade(
-                  newValues,
-                ));
+                context
+                    .read<BoulderFilterGradeBloc>()
+                    .add(BoulderFilterGradeEvent(
+                      newValues,
+                    ));
               },
             )),
       ],

--- a/lib/components/boulder_list_filter_modal.dart
+++ b/lib/components/boulder_list_filter_modal.dart
@@ -1,4 +1,3 @@
-import 'package:breizh_blok_mobile/blocs/boulder_filter_bloc.dart';
 import 'package:breizh_blok_mobile/components/modal_closing_button.dart';
 import 'package:breizh_blok_mobile/repositories/grade_repository.dart';
 import 'package:flutter/material.dart';
@@ -8,9 +7,7 @@ import 'package:breizh_blok_mobile/models/collection_items.dart';
 import 'package:breizh_blok_mobile/models/grade.dart';
 
 class BoulderListFilterModal extends StatelessWidget {
-  final BoulderFilterBloc boulderFilterBloc;
-  BoulderListFilterModal({Key? key, required this.boulderFilterBloc})
-      : super(key: key);
+  BoulderListFilterModal({Key? key}) : super(key: key);
 
   final _gradeRepository = GradeRepository();
 
@@ -42,7 +39,6 @@ class BoulderListFilterModal extends StatelessWidget {
                         BoulderListFilterGrade(
                           key: const Key('boulder-list-filter-grade'),
                           allGrades: data,
-                          boulderFilterBloc: boulderFilterBloc,
                         ),
                       ],
                     ),

--- a/lib/components/boulder_list_filter_modal.dart
+++ b/lib/components/boulder_list_filter_modal.dart
@@ -1,3 +1,4 @@
+import 'package:breizh_blok_mobile/blocs/boulder_filter_bloc.dart';
 import 'package:breizh_blok_mobile/components/modal_closing_button.dart';
 import 'package:breizh_blok_mobile/repositories/grade_repository.dart';
 import 'package:flutter/material.dart';
@@ -7,7 +8,9 @@ import 'package:breizh_blok_mobile/models/collection_items.dart';
 import 'package:breizh_blok_mobile/models/grade.dart';
 
 class BoulderListFilterModal extends StatelessWidget {
-  BoulderListFilterModal({Key? key}) : super(key: key);
+  final BoulderFilterBloc boulderFilterBloc;
+  BoulderListFilterModal({Key? key, required this.boulderFilterBloc})
+      : super(key: key);
 
   final _gradeRepository = GradeRepository();
 
@@ -24,26 +27,23 @@ class BoulderListFilterModal extends StatelessWidget {
           future: _fetch(),
           builder: (BuildContext context,
               AsyncSnapshot<CollectionItems<Grade>> snapshot) {
-            List<Widget> widgets = [
-              const SizedBox(
-                height: 20,
-              ),
-              if (snapshot.hasData && snapshot.data!.totalItems > 1) ...[
-                BoulderListFilterGrade(
-                  key: const Key('boulder-list-filter-grade'),
-                  allGrades: snapshot.data!,
-                ),
-              ],
-            ];
+            final data = snapshot.data;
 
-            if (snapshot.hasData || snapshot.hasError) {
+            if (data != null && data.totalItems > 1) {
               return SafeArea(
                 child: Center(
                   child: Container(
                     constraints: const BoxConstraints(maxWidth: 400),
                     child: Column(
                       children: [
-                        ...widgets,
+                        const SizedBox(
+                          height: 20,
+                        ),
+                        BoulderListFilterGrade(
+                          key: const Key('boulder-list-filter-grade'),
+                          allGrades: data,
+                          boulderFilterBloc: boulderFilterBloc,
+                        ),
                       ],
                     ),
                   ),

--- a/lib/components/boulder_map.dart
+++ b/lib/components/boulder_map.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:breizh_blok_mobile/blocs/boulder_filter_bloc.dart';
 import 'package:breizh_blok_mobile/blocs/boulder_marker_bloc.dart';
+import 'package:breizh_blok_mobile/blocs/boulder_order_bloc.dart';
 import 'package:breizh_blok_mobile/blocs/map_bloc.dart';
 import 'package:breizh_blok_mobile/components/base_map.dart';
 import 'package:breizh_blok_mobile/components/error_indicator.dart';
@@ -130,7 +131,9 @@ class _BoulderMapState extends State<BoulderMap> {
             onTryAgain: () {
               context.read<BoulderMarkerBloc>().add(
                     BoulderMarkerRequested(
-                        filterState: context.read<BoulderFilterBloc>().state),
+                      filterState: context.read<BoulderFilterBloc>().state,
+                      orderQueryParam: context.read<BoulderOrderBloc>().state,
+                    ),
                   );
             },
           );

--- a/lib/components/filter_boulders_button.dart
+++ b/lib/components/filter_boulders_button.dart
@@ -2,6 +2,7 @@ import 'package:breizh_blok_mobile/blocs/boulder_filter_bloc.dart';
 import 'package:breizh_blok_mobile/components/boulder_list_filter_modal.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 
 class FilterBouldersButton extends StatelessWidget {
   final BoulderFilterBloc boulderFilterBloc;
@@ -12,30 +13,43 @@ class FilterBouldersButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return TextButton(
-      key: const Key('boulder-list-filter-button'),
-      child: const Row(
-        children: [
-          Icon(CupertinoIcons.line_horizontal_3_decrease),
-          SizedBox(
-            width: 5,
-          ),
-          Text('Filtrer')
-        ],
-      ),
-      onPressed: () {
-        showModalBottomSheet(
-            isScrollControlled: true,
-            context: context,
-            builder: (context) {
-              return FractionallySizedBox(
-                heightFactor: 0.5,
-                child: BoulderListFilterModal(
-                  boulderFilterBloc: boulderFilterBloc,
-                ),
-              );
-            });
-      },
-    );
+    return BlocBuilder<BoulderFilterBloc, BoulderFilterState>(
+        builder: (context, state) {
+      final button = TextButton(
+        key: const Key('boulder-list-filter-button'),
+        child: const Row(
+          children: [
+            Icon(CupertinoIcons.line_horizontal_3_decrease),
+            SizedBox(
+              width: 5,
+            ),
+            Text('Filtrer')
+          ],
+        ),
+        onPressed: () {
+          showModalBottomSheet(
+              isScrollControlled: true,
+              context: context,
+              builder: (context) {
+                return FractionallySizedBox(
+                  heightFactor: 0.5,
+                  child: BoulderListFilterModal(
+                    boulderFilterBloc: boulderFilterBloc,
+                  ),
+                );
+              });
+        },
+      );
+
+      if (state.grades.isEmpty) {
+        return button;
+      }
+
+      return Badge(
+        alignment: const Alignment(.95, -.65),
+        smallSize: 10,
+        child: button,
+      );
+    });
   }
 }

--- a/lib/components/filter_boulders_button.dart
+++ b/lib/components/filter_boulders_button.dart
@@ -1,9 +1,14 @@
+import 'package:breizh_blok_mobile/blocs/boulder_filter_bloc.dart';
 import 'package:breizh_blok_mobile/components/boulder_list_filter_modal.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
 class FilterBouldersButton extends StatelessWidget {
-  const FilterBouldersButton({Key? key}) : super(key: key);
+  final BoulderFilterBloc boulderFilterBloc;
+  const FilterBouldersButton({
+    Key? key,
+    required this.boulderFilterBloc,
+  }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -24,8 +29,10 @@ class FilterBouldersButton extends StatelessWidget {
             context: context,
             builder: (context) {
               return FractionallySizedBox(
-                heightFactor: 0.6,
-                child: BoulderListFilterModal(),
+                heightFactor: 0.5,
+                child: BoulderListFilterModal(
+                  boulderFilterBloc: boulderFilterBloc,
+                ),
               );
             });
       },

--- a/lib/components/filter_boulders_button.dart
+++ b/lib/components/filter_boulders_button.dart
@@ -1,19 +1,17 @@
-import 'package:breizh_blok_mobile/blocs/boulder_filter_bloc.dart';
+import 'package:breizh_blok_mobile/blocs/boulder_filter_grade_bloc.dart';
 import 'package:breizh_blok_mobile/components/boulder_list_filter_modal.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 class FilterBouldersButton extends StatelessWidget {
-  final BoulderFilterBloc boulderFilterBloc;
   const FilterBouldersButton({
     Key? key,
-    required this.boulderFilterBloc,
   }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    return BlocBuilder<BoulderFilterBloc, BoulderFilterState>(
+    return BlocBuilder<BoulderFilterGradeBloc, BoulderFilterGradeState>(
         builder: (context, state) {
       final button = TextButton(
         key: const Key('boulder-list-filter-button'),
@@ -33,9 +31,7 @@ class FilterBouldersButton extends StatelessWidget {
               builder: (context) {
                 return FractionallySizedBox(
                   heightFactor: 0.5,
-                  child: BoulderListFilterModal(
-                    boulderFilterBloc: boulderFilterBloc,
-                  ),
+                  child: BoulderListFilterModal(),
                 );
               });
         },

--- a/lib/components/sort_boulders_button.dart
+++ b/lib/components/sort_boulders_button.dart
@@ -1,4 +1,4 @@
-import 'package:breizh_blok_mobile/blocs/boulder_filter_bloc.dart';
+import 'package:breizh_blok_mobile/blocs/boulder_order_bloc.dart';
 import 'package:breizh_blok_mobile/models/order_query_param.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
@@ -55,45 +55,39 @@ class SortBouldersButton extends StatelessWidget {
       onPressed: () {
         showDialog(
           context: context,
-          builder: (dialogContext) => BlocProvider.value(
-            value: BlocProvider.of<BoulderFilterBloc>(context),
-            child: AlertDialog(
-              alignment: Alignment.topCenter,
-              contentPadding: EdgeInsets.zero,
-              title: const Text("Afficher en 1er:"),
-              content: Padding(
-                padding: const EdgeInsets.only(top: 8.0),
-                child: BlocBuilder<BoulderFilterBloc, BoulderFilterState>(
-                  buildWhen: (previousValue, value) {
-                    return previousValue.order != value.order;
-                  },
-                  builder: (context, state) {
-                    OrderQueryParam groupValue = state.order;
+          builder: (dialogContext) => AlertDialog(
+            alignment: Alignment.topCenter,
+            contentPadding: EdgeInsets.zero,
+            title: const Text("Afficher en 1er:"),
+            content: Padding(
+              padding: const EdgeInsets.only(top: 8.0),
+              child: BlocBuilder<BoulderOrderBloc, OrderQueryParam>(
+                builder: (context, state) {
+                  OrderQueryParam groupValue = state;
 
-                    return Column(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        for (var orderChoice in OrderChoice.values)
-                          RadioListTile<OrderQueryParam>(
-                            value: orderChoice.orderQueryParam,
-                            groupValue: groupValue,
-                            onChanged: (value) {
-                              if (value == null) {
-                                return;
-                              }
-                              context.read<BoulderFilterBloc>().add(
-                                    BoulderFilterOrder(
-                                      orderChoice.orderQueryParam,
-                                    ),
-                                  );
-                              Navigator.of(context).pop();
-                            },
-                            title: Text(orderChoice.label),
-                          ),
-                      ],
-                    );
-                  },
-                ),
+                  return Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      for (var orderChoice in OrderChoice.values)
+                        RadioListTile<OrderQueryParam>(
+                          value: orderChoice.orderQueryParam,
+                          groupValue: groupValue,
+                          onChanged: (value) {
+                            if (value == null) {
+                              return;
+                            }
+                            context.read<BoulderOrderBloc>().add(
+                                  BoulderOrderEvent(
+                                    orderChoice.orderQueryParam,
+                                  ),
+                                );
+                            Navigator.of(context).pop();
+                          },
+                          title: Text(orderChoice.label),
+                        ),
+                    ],
+                  );
+                },
               ),
             ),
           ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,7 +1,9 @@
 import 'package:breizh_blok_mobile/blocs/boulder_marker_bloc.dart';
+import 'package:breizh_blok_mobile/blocs/boulder_order_bloc.dart';
 import 'package:breizh_blok_mobile/blocs/map_bloc.dart';
 import 'package:breizh_blok_mobile/blocs/map_permission_bloc.dart';
 import 'package:breizh_blok_mobile/location_provider.dart';
+import 'package:breizh_blok_mobile/models/order_query_param.dart';
 import 'package:breizh_blok_mobile/views/boulder_area_details_view.dart';
 import 'package:breizh_blok_mobile/views/municipality_details_view.dart';
 import 'package:flutter/material.dart';
@@ -33,6 +35,10 @@ main({
     BoulderFilterState(),
   );
 
+  final BoulderOrderBloc boulderOrderBloc = BoulderOrderBloc(
+    const OrderQueryParam(direction: 'desc', name: 'order[id]'),
+  );
+
   final boulderMarkerBloc = BoulderMarkerBloc();
 
   await SentryFlutter.init(
@@ -49,6 +55,9 @@ main({
           ),
           BlocProvider<BoulderFilterBloc>(
             create: (BuildContext context) => boulderFilterBloc,
+          ),
+          BlocProvider<BoulderOrderBloc>(
+            create: (BuildContext context) => boulderOrderBloc,
           ),
           BlocProvider<BoulderMarkerBloc>(
             create: (BuildContext context) => boulderMarkerBloc,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,3 +1,4 @@
+import 'package:breizh_blok_mobile/blocs/boulder_filter_grade_bloc.dart';
 import 'package:breizh_blok_mobile/blocs/boulder_marker_bloc.dart';
 import 'package:breizh_blok_mobile/blocs/boulder_order_bloc.dart';
 import 'package:breizh_blok_mobile/blocs/map_bloc.dart';
@@ -39,6 +40,9 @@ main({
     const OrderQueryParam(direction: 'desc', name: 'order[id]'),
   );
 
+  final BoulderFilterGradeBloc boulderFilterGradeBloc =
+      BoulderFilterGradeBloc(BoulderFilterGradeState());
+
   final boulderMarkerBloc = BoulderMarkerBloc();
 
   await SentryFlutter.init(
@@ -58,6 +62,9 @@ main({
           ),
           BlocProvider<BoulderOrderBloc>(
             create: (BuildContext context) => boulderOrderBloc,
+          ),
+          BlocProvider<BoulderFilterGradeBloc>(
+            create: (BuildContext context) => boulderFilterGradeBloc,
           ),
           BlocProvider<BoulderMarkerBloc>(
             create: (BuildContext context) => boulderMarkerBloc,

--- a/lib/models/grade.dart
+++ b/lib/models/grade.dart
@@ -1,8 +1,10 @@
-class Grade {
+import 'package:equatable/equatable.dart';
+
+class Grade extends Equatable {
   final String name;
   final String iri;
 
-  Grade({
+  const Grade({
     required this.iri,
     required this.name,
   });
@@ -13,4 +15,7 @@ class Grade {
       name: json['name'],
     );
   }
+
+  @override
+  List<Object?> get props => [iri];
 }

--- a/lib/utils/boulder_list_query_params_builder.dart
+++ b/lib/utils/boulder_list_query_params_builder.dart
@@ -1,9 +1,11 @@
 import 'package:breizh_blok_mobile/blocs/boulder_filter_bloc.dart';
+import 'package:breizh_blok_mobile/models/order_query_param.dart';
 
 class BoulderListQueryParamsBuilder {
-  static Future<Map<String, List<String>>> compute(
-    BoulderFilterState filterState,
-  ) async {
+  static Future<Map<String, List<String>>> compute({
+    required BoulderFilterState filterState,
+    required OrderQueryParam orderQueryParam,
+  }) async {
     Map<String, List<String>> queryParams = {};
     if (filterState.term != null) {
       queryParams['term'] = [filterState.term!];
@@ -15,7 +17,7 @@ class BoulderListQueryParamsBuilder {
     queryParams['grade.name[]'] =
         filterState.grades.map((e) => e.name).toList();
 
-    queryParams[filterState.order.name] = [filterState.order.direction];
+    queryParams[orderQueryParam.name] = [orderQueryParam.direction];
 
     return queryParams;
   }

--- a/lib/utils/boulder_list_query_params_builder.dart
+++ b/lib/utils/boulder_list_query_params_builder.dart
@@ -1,10 +1,12 @@
 import 'package:breizh_blok_mobile/blocs/boulder_filter_bloc.dart';
+import 'package:breizh_blok_mobile/models/grade.dart';
 import 'package:breizh_blok_mobile/models/order_query_param.dart';
 
 class BoulderListQueryParamsBuilder {
   static Future<Map<String, List<String>>> compute({
-    required BoulderFilterState filterState,
+    required Set<Grade> grades,
     required OrderQueryParam orderQueryParam,
+    required BoulderFilterState filterState,
   }) async {
     Map<String, List<String>> queryParams = {};
     if (filterState.term != null) {
@@ -14,8 +16,7 @@ class BoulderListQueryParamsBuilder {
         .map((e) => e.iri.replaceAll('/boulder_areas/', ''))
         .toList();
 
-    queryParams['grade.name[]'] =
-        filterState.grades.map((e) => e.name).toList();
+    queryParams['grade.name[]'] = grades.map((e) => e.name).toList();
 
     queryParams[orderQueryParam.name] = [orderQueryParam.direction];
 

--- a/lib/utils/map_utils.dart
+++ b/lib/utils/map_utils.dart
@@ -2,11 +2,11 @@ import 'dart:ui' as ui;
 
 import 'package:breizh_blok_mobile/blocs/boulder_bloc.dart';
 import 'package:breizh_blok_mobile/blocs/boulder_filter_bloc.dart';
+import 'package:breizh_blok_mobile/blocs/boulder_order_bloc.dart';
 import 'package:breizh_blok_mobile/components/boulder_list_builder.dart';
 import 'package:breizh_blok_mobile/components/modal_closing_button.dart';
 import 'package:breizh_blok_mobile/models/boulder_marker.dart';
 import 'package:breizh_blok_mobile/models/location.dart';
-import 'package:breizh_blok_mobile/models/order_query_param.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -80,10 +80,8 @@ Future<Uint8List> getBytesFromAsset(String path, int width) async {
 }
 
 Future<Marker> Function(Cluster<BoulderMarker>) markerBuilderFactory(
-  BuildContext context, {
-  required BoulderFilterState boulderFilterState,
-  required OrderQueryParam orderQueryParam,
-}) {
+  BuildContext context,
+) {
   return (cluster) async {
     return Marker(
       markerId: MarkerId(cluster.getId()),
@@ -93,34 +91,32 @@ Future<Marker> Function(Cluster<BoulderMarker>) markerBuilderFactory(
           context: context,
           isScrollControlled: true,
           builder: (BuildContext context) {
-            return BlocProvider(
-              create: (context) => BoulderFilterBloc(boulderFilterState),
-              child: Builder(builder: (context) {
-                return FractionallySizedBox(
-                  heightFactor: 0.8,
-                  child: Scaffold(
-                    floatingActionButton: const ModalClosingButton(),
-                    floatingActionButtonLocation:
-                        FloatingActionButtonLocation.endTop,
-                    body: BoulderListBuilder(
-                      onClickTile: (id) => {
-                        GoRouter.of(context).pop(),
-                      },
-                      onPageRequested: (int page) {
-                        return BoulderMapViewRequested(
-                          page: page,
-                          boulderIds: cluster.items
-                              .map((e) => e.id.toString())
-                              .toList(),
-                          filterState: boulderFilterState,
-                          orderQueryParam: orderQueryParam,
-                        );
-                      },
-                    ),
+            return Builder(builder: (context) {
+              return FractionallySizedBox(
+                heightFactor: 0.8,
+                child: Scaffold(
+                  floatingActionButton: const ModalClosingButton(),
+                  floatingActionButtonLocation:
+                      FloatingActionButtonLocation.endTop,
+                  body: BoulderListBuilder(
+                    boulderFilterBloc: BoulderFilterBloc(BoulderFilterState()),
+                    onClickTile: (id) => {
+                      GoRouter.of(context).pop(),
+                    },
+                    onPageRequested: (int page) {
+                      return BoulderMapViewRequested(
+                        page: page,
+                        boulderIds:
+                            cluster.items.map((e) => e.id.toString()).toList(),
+                        filterState: BoulderFilterState(),
+                        orderQueryParam: context.read<BoulderOrderBloc>().state,
+                      );
+                    },
+                    showFilterButton: false,
                   ),
-                );
-              }),
-            );
+                ),
+              );
+            });
           },
         );
       },

--- a/lib/utils/map_utils.dart
+++ b/lib/utils/map_utils.dart
@@ -6,6 +6,7 @@ import 'package:breizh_blok_mobile/components/boulder_list_builder.dart';
 import 'package:breizh_blok_mobile/components/modal_closing_button.dart';
 import 'package:breizh_blok_mobile/models/boulder_marker.dart';
 import 'package:breizh_blok_mobile/models/location.dart';
+import 'package:breizh_blok_mobile/models/order_query_param.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -79,8 +80,10 @@ Future<Uint8List> getBytesFromAsset(String path, int width) async {
 }
 
 Future<Marker> Function(Cluster<BoulderMarker>) markerBuilderFactory(
-    BuildContext context,
-    {required BoulderFilterState boulderFilterState}) {
+  BuildContext context, {
+  required BoulderFilterState boulderFilterState,
+  required OrderQueryParam orderQueryParam,
+}) {
   return (cluster) async {
     return Marker(
       markerId: MarkerId(cluster.getId()),
@@ -110,6 +113,7 @@ Future<Marker> Function(Cluster<BoulderMarker>) markerBuilderFactory(
                               .map((e) => e.id.toString())
                               .toList(),
                           filterState: boulderFilterState,
+                          orderQueryParam: orderQueryParam,
                         );
                       },
                     ),

--- a/lib/views/home_map_view.dart
+++ b/lib/views/home_map_view.dart
@@ -1,4 +1,5 @@
 import 'package:breizh_blok_mobile/blocs/boulder_filter_bloc.dart';
+import 'package:breizh_blok_mobile/blocs/boulder_order_bloc.dart';
 import 'package:breizh_blok_mobile/blocs/map_bloc.dart';
 import 'package:breizh_blok_mobile/components/boulder_map.dart';
 import 'package:breizh_blok_mobile/utils/map_utils.dart';
@@ -26,6 +27,7 @@ class _HomeMapViewState extends State<HomeMapView> {
       boulderMarkerBuilder: markerBuilderFactory(
         context,
         boulderFilterState: BoulderFilterState(),
+        orderQueryParam: context.read<BoulderOrderBloc>().state,
       ),
     );
   }

--- a/lib/views/home_map_view.dart
+++ b/lib/views/home_map_view.dart
@@ -1,4 +1,3 @@
-import 'package:breizh_blok_mobile/blocs/boulder_filter_bloc.dart';
 import 'package:breizh_blok_mobile/blocs/map_bloc.dart';
 import 'package:breizh_blok_mobile/components/boulder_map.dart';
 import 'package:breizh_blok_mobile/utils/map_utils.dart';

--- a/lib/views/home_map_view.dart
+++ b/lib/views/home_map_view.dart
@@ -1,5 +1,4 @@
 import 'package:breizh_blok_mobile/blocs/boulder_filter_bloc.dart';
-import 'package:breizh_blok_mobile/blocs/boulder_order_bloc.dart';
 import 'package:breizh_blok_mobile/blocs/map_bloc.dart';
 import 'package:breizh_blok_mobile/components/boulder_map.dart';
 import 'package:breizh_blok_mobile/utils/map_utils.dart';
@@ -26,8 +25,6 @@ class _HomeMapViewState extends State<HomeMapView> {
       initialPosition: context.read<MapBloc>().state.mapLatLng,
       boulderMarkerBuilder: markerBuilderFactory(
         context,
-        boulderFilterState: BoulderFilterState(),
-        orderQueryParam: context.read<BoulderOrderBloc>().state,
       ),
     );
   }

--- a/lib/views/home_view.dart
+++ b/lib/views/home_view.dart
@@ -1,5 +1,6 @@
 import 'package:breizh_blok_mobile/blocs/boulder_filter_bloc.dart';
 import 'package:breizh_blok_mobile/blocs/boulder_marker_bloc.dart';
+import 'package:breizh_blok_mobile/blocs/boulder_order_bloc.dart';
 import 'package:breizh_blok_mobile/components/lazy_indexed_stack.dart';
 import 'package:breizh_blok_mobile/views/home_municipalities_view.dart';
 import 'package:flutter/cupertino.dart';
@@ -34,6 +35,7 @@ class HomeView extends StatelessWidget {
             context.read<BoulderMarkerBloc>().add(
                   BoulderMarkerRequested(
                     filterState: context.read<BoulderFilterBloc>().state,
+                    orderQueryParam: context.read<BoulderOrderBloc>().state,
                   ),
                 );
           }
@@ -55,6 +57,7 @@ class HomeView extends StatelessWidget {
                 onPageRequested: (int page) => BoulderListViewRequested(
                   page: page,
                   filterState: context.read<BoulderFilterBloc>().state,
+                  orderQueryParam: context.read<BoulderOrderBloc>().state,
                 ),
               ),
               const HomeMapView(),

--- a/lib/views/home_view.dart
+++ b/lib/views/home_view.dart
@@ -59,6 +59,7 @@ class HomeView extends StatelessWidget {
                   filterState: context.read<BoulderFilterBloc>().state,
                   orderQueryParam: context.read<BoulderOrderBloc>().state,
                 ),
+                boulderFilterBloc: context.read<BoulderFilterBloc>(),
               ),
               const HomeMapView(),
               const HomeMunicipalitiesView(),

--- a/lib/views/home_view.dart
+++ b/lib/views/home_view.dart
@@ -1,4 +1,5 @@
 import 'package:breizh_blok_mobile/blocs/boulder_filter_bloc.dart';
+import 'package:breizh_blok_mobile/blocs/boulder_filter_grade_bloc.dart';
 import 'package:breizh_blok_mobile/blocs/boulder_marker_bloc.dart';
 import 'package:breizh_blok_mobile/blocs/boulder_order_bloc.dart';
 import 'package:breizh_blok_mobile/components/lazy_indexed_stack.dart';
@@ -58,6 +59,7 @@ class HomeView extends StatelessWidget {
                   page: page,
                   filterState: context.read<BoulderFilterBloc>().state,
                   orderQueryParam: context.read<BoulderOrderBloc>().state,
+                  grades: context.read<BoulderFilterGradeBloc>().state.grades,
                 ),
                 boulderFilterBloc: context.read<BoulderFilterBloc>(),
               ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ publish_to: 'none'
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 1.5.6+1.5.06
+version: 1.5.7+1.5.07
 
 environment:
   sdk: '>=3.0.0 <4.0.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ publish_to: 'none'
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 1.5.7+1.5.07
+version: 1.6.0+1.6.00
 
 environment:
   sdk: '>=3.0.0 <4.0.0'

--- a/test/unit/blocs/boulder_filter_bloc_test.dart
+++ b/test/unit/blocs/boulder_filter_bloc_test.dart
@@ -47,7 +47,7 @@ void main() {
       ],
     );
 
-    final referenceGrade = Grade(
+    const referenceGrade = Grade(
       iri: '1',
       name: '6a',
     );

--- a/test/unit/blocs/boulder_filter_bloc_test.dart
+++ b/test/unit/blocs/boulder_filter_bloc_test.dart
@@ -1,7 +1,6 @@
 import 'package:bloc_test/bloc_test.dart';
 import 'package:breizh_blok_mobile/blocs/boulder_filter_bloc.dart';
 import 'package:breizh_blok_mobile/models/boulder_area.dart';
-import 'package:breizh_blok_mobile/models/grade.dart';
 import 'package:breizh_blok_mobile/models/municipality.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -13,7 +12,6 @@ void main() {
       verify: (BoulderFilterBloc bloc) {
         expect(bloc.state.term, null);
         expect(bloc.state.boulderAreas, <BoulderArea>{});
-        expect(bloc.state.grades, <Grade>{});
       },
     );
 
@@ -43,26 +41,6 @@ void main() {
       expect: () => [
         BoulderFilterState(boulderAreas: {
           referenceBoulderArea,
-        })
-      ],
-    );
-
-    const referenceGrade = Grade(
-      iri: '1',
-      name: '6a',
-    );
-
-    blocTest(
-      'BoulderFilterGrade event OK',
-      build: () => BoulderFilterBloc(BoulderFilterState()),
-      act: (BoulderFilterBloc bloc) => bloc.add(BoulderFilterGrade(
-        {
-          referenceGrade,
-        },
-      )),
-      expect: () => [
-        BoulderFilterState(grades: {
-          referenceGrade,
         })
       ],
     );

--- a/test/unit/blocs/boulder_filter_bloc_test.dart
+++ b/test/unit/blocs/boulder_filter_bloc_test.dart
@@ -3,7 +3,6 @@ import 'package:breizh_blok_mobile/blocs/boulder_filter_bloc.dart';
 import 'package:breizh_blok_mobile/models/boulder_area.dart';
 import 'package:breizh_blok_mobile/models/grade.dart';
 import 'package:breizh_blok_mobile/models/municipality.dart';
-import 'package:breizh_blok_mobile/models/order_query_param.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -15,10 +14,6 @@ void main() {
         expect(bloc.state.term, null);
         expect(bloc.state.boulderAreas, <BoulderArea>{});
         expect(bloc.state.grades, <Grade>{});
-        expect(
-          bloc.state.order,
-          const OrderQueryParam(name: 'order[id]', direction: 'desc'),
-        );
       },
     );
 
@@ -69,21 +64,6 @@ void main() {
         BoulderFilterState(grades: {
           referenceGrade,
         })
-      ],
-    );
-
-    const referenceOrder =
-        OrderQueryParam(name: 'order[name]', direction: 'asc');
-    blocTest(
-      'BoulderFilterOrder event OK',
-      build: () => BoulderFilterBloc(BoulderFilterState()),
-      act: (BoulderFilterBloc bloc) => bloc.add(
-        BoulderFilterOrder(referenceOrder),
-      ),
-      expect: () => [
-        BoulderFilterState(
-          order: referenceOrder,
-        )
       ],
     );
   });

--- a/test/unit/blocs/boulder_filter_grade_bloc_test.dart
+++ b/test/unit/blocs/boulder_filter_grade_bloc_test.dart
@@ -1,0 +1,34 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:breizh_blok_mobile/blocs/boulder_filter_grade_bloc.dart';
+import 'package:breizh_blok_mobile/models/grade.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('BoulderFilterGradeBloc', () {
+    blocTest(
+      'default state OK',
+      build: () => BoulderFilterGradeBloc(BoulderFilterGradeState()),
+      verify: (BoulderFilterGradeBloc bloc) {
+        expect(bloc.state.grades, <Grade>{});
+      },
+    );
+
+    const referenceGrade = Grade(
+      iri: '1',
+      name: '6a',
+    );
+
+    blocTest(
+      'BoulderFilterGrade event OK',
+      build: () => BoulderFilterGradeBloc(BoulderFilterGradeState()),
+      act: (BoulderFilterGradeBloc bloc) => bloc.add(BoulderFilterGradeEvent(
+        {
+          referenceGrade,
+        },
+      )),
+      expect: () => [
+        BoulderFilterGradeState(grades: {referenceGrade})
+      ],
+    );
+  });
+}

--- a/test/unit/blocs/boulder_order_bloc_test.dart
+++ b/test/unit/blocs/boulder_order_bloc_test.dart
@@ -1,0 +1,30 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:breizh_blok_mobile/blocs/boulder_order_bloc.dart';
+import 'package:breizh_blok_mobile/models/order_query_param.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('BoulderFilterBloc', () {
+    blocTest(
+      'default state OK',
+      build: () => BoulderOrderBloc(
+          const OrderQueryParam(direction: 'desc', name: 'order[id]')),
+      verify: (BoulderOrderBloc bloc) {
+        expect(bloc.state.direction, 'desc');
+        expect(bloc.state.name, 'order[id]');
+      },
+    );
+
+    blocTest(
+      'BoulderOrderEvent OK',
+      build: () => BoulderOrderBloc(
+          const OrderQueryParam(direction: 'desc', name: 'order[id]')),
+      act: (BoulderOrderBloc bloc) => bloc.add(
+        BoulderOrderEvent(
+          const OrderQueryParam(direction: 'asc', name: 'name'),
+        ),
+      ),
+      expect: () => [const OrderQueryParam(direction: 'asc', name: 'name')],
+    );
+  });
+}

--- a/test/unit/models/boulder_area_test.dart
+++ b/test/unit/models/boulder_area_test.dart
@@ -74,7 +74,7 @@ void main() {
 
           final boulderArea3 = boulderAreaRef.copyWith(
             numberOfBoulders: 5,
-            lowestGrade: Grade(iri: '', name: '5c'),
+            lowestGrade: const Grade(iri: '', name: '5c'),
           );
 
           expect(boulderArea3.numberOfBoulders, 5);
@@ -84,7 +84,7 @@ void main() {
 
           final boulderArea4 = boulderAreaRef.copyWith(
             numberOfBoulders: 5,
-            highestGrade: Grade(iri: '', name: '5c'),
+            highestGrade: const Grade(iri: '', name: '5c'),
           );
 
           expect(boulderArea4.numberOfBoulders, 5);
@@ -96,8 +96,8 @@ void main() {
         test('return "n blocs en ..."', () {
           final boulderArea = boulderAreaRef.copyWith(
             numberOfBoulders: 5,
-            lowestGrade: Grade(iri: '', name: '5c'),
-            highestGrade: Grade(iri: '', name: '5c'),
+            lowestGrade: const Grade(iri: '', name: '5c'),
+            highestGrade: const Grade(iri: '', name: '5c'),
           );
 
           expect(boulderArea.numberOfBoulders, 5);
@@ -107,8 +107,8 @@ void main() {
 
           final boulderArea2 = boulderAreaRef.copyWith(
             numberOfBoulders: 5,
-            lowestGrade: Grade(iri: '', name: '5a'),
-            highestGrade: Grade(iri: '', name: '5c'),
+            lowestGrade: const Grade(iri: '', name: '5a'),
+            highestGrade: const Grade(iri: '', name: '5c'),
           );
 
           expect(boulderArea2.numberOfBoulders, 5);

--- a/test/widget/boulder_list_filter_grade_test.dart
+++ b/test/widget/boulder_list_filter_grade_test.dart
@@ -1,0 +1,83 @@
+// ignore_for_file: avoid_print
+
+import 'package:breizh_blok_mobile/blocs/boulder_filter_bloc.dart';
+import 'package:breizh_blok_mobile/components/boulder_list_filter_grade.dart';
+import 'package:breizh_blok_mobile/models/collection_items.dart';
+import 'package:breizh_blok_mobile/models/grade.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:syncfusion_flutter_sliders/sliders.dart';
+
+void main() {
+  final grades = [
+    const Grade(
+      iri: '/grades/1',
+      name: '5',
+    ),
+    const Grade(
+      iri: '/grades/2',
+      name: '6a',
+    ),
+    const Grade(
+      iri: '/grades/3',
+      name: '6b',
+    ),
+    const Grade(
+      iri: '/grades/4',
+      name: '6c',
+    ),
+    const Grade(
+      iri: '/grades/4',
+      name: '7a',
+    )
+  ];
+  final CollectionItems<Grade> gradeCollection =
+      CollectionItems(items: grades, totalItems: grades.length);
+  group('BoulderListFilterGrade', () {
+    testWidgets('set bloc values correctly after selecting some grades',
+        (tester) async {
+      final boulderFilterBloc = BoulderFilterBloc(BoulderFilterState());
+      expect(boulderFilterBloc.state.grades.length, 0);
+
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: BoulderListFilterGrade(
+            allGrades: gradeCollection,
+            boulderFilterBloc: boulderFilterBloc,
+          ),
+        ),
+      ));
+
+      await tester.pumpAndSettle();
+      final Offset leftTarget =
+          tester.getTopLeft(find.byType(SfRangeSlider)).translate(20, 16);
+      final Offset rightTarget =
+          tester.getTopRight(find.byType(SfRangeSlider)).translate(-20, 16);
+
+      final middleOffset = Offset((leftTarget.dx + rightTarget.dx) / 2, 0);
+
+      await tester.dragFrom(rightTarget, -middleOffset);
+      await tester.pumpAndSettle();
+
+      expect(boulderFilterBloc.state.grades, {
+        const Grade(
+          iri: '/grades/1',
+          name: '5',
+        ),
+        const Grade(
+          iri: '/grades/2',
+          name: '6a',
+        ),
+        const Grade(
+          iri: '/grades/3',
+          name: '6b',
+        ),
+      });
+
+      await tester.dragFrom(
+          rightTarget - middleOffset, middleOffset + const Offset(1, 0));
+
+      expect(boulderFilterBloc.state.grades, <Grade>{});
+    });
+  });
+}

--- a/test/widget/boulder_list_filter_grade_test.dart
+++ b/test/widget/boulder_list_filter_grade_test.dart
@@ -1,10 +1,11 @@
 // ignore_for_file: avoid_print
 
-import 'package:breizh_blok_mobile/blocs/boulder_filter_bloc.dart';
+import 'package:breizh_blok_mobile/blocs/boulder_filter_grade_bloc.dart';
 import 'package:breizh_blok_mobile/components/boulder_list_filter_grade.dart';
 import 'package:breizh_blok_mobile/models/collection_items.dart';
 import 'package:breizh_blok_mobile/models/grade.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:syncfusion_flutter_sliders/sliders.dart';
 
@@ -36,15 +37,20 @@ void main() {
   group('BoulderListFilterGrade', () {
     testWidgets('set bloc values correctly after selecting some grades',
         (tester) async {
-      final boulderFilterBloc = BoulderFilterBloc(BoulderFilterState());
-      expect(boulderFilterBloc.state.grades.length, 0);
+      final boulderFilterGradeBloc =
+          BoulderFilterGradeBloc(BoulderFilterGradeState());
+      expect(boulderFilterGradeBloc.state.grades.length, 0);
 
       await tester.pumpWidget(MaterialApp(
-        home: Scaffold(
-          body: BoulderListFilterGrade(
-            allGrades: gradeCollection,
-            boulderFilterBloc: boulderFilterBloc,
-          ),
+        home: BlocProvider(
+          create: (context) => boulderFilterGradeBloc,
+          child: Builder(builder: (context) {
+            return Scaffold(
+              body: BoulderListFilterGrade(
+                allGrades: gradeCollection,
+              ),
+            );
+          }),
         ),
       ));
 
@@ -59,7 +65,7 @@ void main() {
       await tester.dragFrom(rightTarget, -middleOffset);
       await tester.pumpAndSettle();
 
-      expect(boulderFilterBloc.state.grades, {
+      expect(boulderFilterGradeBloc.state.grades, {
         const Grade(
           iri: '/grades/1',
           name: '5',
@@ -77,7 +83,7 @@ void main() {
       await tester.dragFrom(
           rightTarget - middleOffset, middleOffset + const Offset(1, 0));
 
-      expect(boulderFilterBloc.state.grades, <Grade>{});
+      expect(boulderFilterGradeBloc.state.grades, <Grade>{});
     });
   });
 }

--- a/test/widget/municipality_details_test.dart
+++ b/test/widget/municipality_details_test.dart
@@ -18,8 +18,8 @@ void main() {
           name: 'generic',
         ),
         numberOfBoulders: 4,
-        lowestGrade: Grade(iri: '', name: '5c'),
-        highestGrade: Grade(iri: '', name: '6c'),
+        lowestGrade: const Grade(iri: '', name: '5c'),
+        highestGrade: const Grade(iri: '', name: '6c'),
       ),
       BoulderArea(
         iri: '/boulder_areas/2',


### PR DESCRIPTION
# develop vers main

## Vérifications manuelles

- [x] exécuter les tests E2E sur iOS
- [x] exécuter les tests E2E sur Android

## Contenu de la release

### Evolutions

- [x] Ajout d'une vue dédiée permettant un accès rapide aux communes et secteurs répertoriés dans l'application
- [x] Suppression des filtres de sélection de lieux depuis la vue "liste", au profit de la vue "Index" nouvellement créée
- [x] rend le tri global à l'application
- [x] ajoute la possibilité de filtrer les blocs selon la cotation depuis l'écran détaillant un secteur 

### Corrections de bug

- [x] quand on clique sur un marqueur de position, la liste des blocs est désormais cohérente avec le nombre de blocs affiché sur le marqueur de position

### Technique

- [x] remplacer Firebase par Sentry